### PR TITLE
Adding Prometheus metrics to AMQP Operator

### DIFF
--- a/helm/hybrid-cloud-amqp-operator/templates/servicemonitor.yaml
+++ b/helm/hybrid-cloud-amqp-operator/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+---
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ include "operator.fullname" . }}-metrics
+  endpoints:
+  - port: {{ .Values.prometheus.portName }}
+    interval: {{ .Values.prometheus.scrapeInterval }}
+    path: {{ .Values.prometheus.path | default "/" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "operator.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/instance: {{ include "operator.fullname" . }}-metrics
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.prometheus.port }}
+      targetPort: {{ .Values.prometheus.port }}
+      protocol: TCP
+      name: {{ .Values.prometheus.portName }}
+  selector:
+    {{- include "operator.selectorLabels" . | nindent 4 }}
+
+{{- end }}

--- a/helm/hybrid-cloud-amqp-operator/values.yaml
+++ b/helm/hybrid-cloud-amqp-operator/values.yaml
@@ -77,3 +77,9 @@ affinity: {}
 
 strategy:
   type: Recreate
+
+prometheus:
+  enabled: true
+  portName: metrics
+  port: 8081
+  scrapeInterval: 30s

--- a/hybridcloud/handlers/broker.py
+++ b/hybridcloud/handlers/broker.py
@@ -5,11 +5,30 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import patch_namespaced_custom_object_status
 from ..util import k8s
 from ..util.constants import BACKOFF
-from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
+from ..util.metrics import (
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, 
+    PROMETHEUS_HANDLER_EXCEPTION_COUNTER, 
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE,
+    ACTIONS,
+    extract_count_from_kopf_index, 
+    initialize_prometheus_handler_metrics, 
+    initialize_prometheus_resource_gauge
+)
 
-# Initialize Prometheus metrics
 _HANDLER_NAME = "broker"
-initialize_prometheus_metrics(_HANDLER_NAME)
+_RESOURCE_TYPE = "AMQPBroker"
+initialize_prometheus_handler_metrics(_HANDLER_NAME)
+initialize_prometheus_resource_gauge(_RESOURCE_TYPE)
+
+
+@kopf.on.create(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
+@kopf.on.update(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
+@kopf.on.delete(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
+def set_resource_count_metric(resource_index: kopf.Index, **_):
+    count = extract_count_from_kopf_index(resource_index, _RESOURCE_TYPE)
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE.labels(type=_RESOURCE_TYPE).set(count)
+
+
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)

--- a/hybridcloud/handlers/broker.py
+++ b/hybridcloud/handlers/broker.py
@@ -5,48 +5,64 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import patch_namespaced_custom_object_status
 from ..util import k8s
 from ..util.constants import BACKOFF
+from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
 
+# Initialize Prometheus metrics
+_HANDLER_NAME = "broker"
+initialize_prometheus_metrics(_HANDLER_NAME)
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
     def broker_resume(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-        broker_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
+        _ACTION_NAME = ACTIONS.RESUME
+        PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
+
+        with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+            broker_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
 
 
 @kopf.on.create(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
 @kopf.on.update(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
 def broker_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-    if ignore_control_label_change(diff):
-        logger.debug("Only control labels removed. Nothing to do.")
-        return
+    _ACTION_NAME = ACTIONS.CREATE_OR_UPDATE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
 
-    if status and "backend" in status:
-        backend_name = status["backend"]
-    else:
-        backend_name = spec.get("backend", config_get("backend", fail_if_missing=True))
-    backend = amqp_backend(backend_name, logger)
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if ignore_control_label_change(diff):
+            logger.debug("Only control labels removed. Nothing to do.")
+            return
 
-    valid, reason = backend.broker_spec_valid(namespace, name, spec)
-    if not valid:
-        _status(name, namespace, status, "failed", f"Validation failed: {reason}")
-        raise kopf.PermanentError("Spec is invalid, check status for details")
+        if status and "backend" in status:
+            backend_name = status["backend"]
+        else:
+            backend_name = spec.get("backend", config_get("backend", fail_if_missing=True))
+        backend = amqp_backend(backend_name, logger)
 
-    # Create broker
-    broker_name = backend.create_or_update_broker(namespace, name, spec)
+        valid, reason = backend.broker_spec_valid(namespace, name, spec)
+        if not valid:
+            _status(name, namespace, status, "failed", f"Validation failed: {reason}")
+            raise kopf.PermanentError("Spec is invalid, check status for details")
 
-    # mark success
-    _status(name, namespace, status, "finished", "Broker created", backend=backend_name, broker_name=broker_name)
+        # Create broker
+        broker_name = backend.create_or_update_broker(namespace, name, spec)
+
+        # mark success
+        _status(name, namespace, status, "finished", "Broker created", backend=backend_name, broker_name=broker_name)
 
 
 @kopf.on.delete(*k8s.AMQPBroker.kopf_on(), backoff=BACKOFF)
 def broker_delete(spec, status, name, namespace, logger, **kwargs):
-    if status and "backend" in status:
-        backend_name = status["backend"]
-    else:
-        backend_name = config_get("backend", fail_if_missing=True)
-    backend = amqp_backend(backend_name, logger)
-    if backend.broker_exists(namespace, name):
-        backend.delete_broker(namespace, name)
+    _ACTION_NAME = ACTIONS.DELETE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
+
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if status and "backend" in status:
+            backend_name = status["backend"]
+        else:
+            backend_name = config_get("backend", fail_if_missing=True)
+        backend = amqp_backend(backend_name, logger)
+        if backend.broker_exists(namespace, name):
+            backend.delete_broker(namespace, name)
 
 
 def _status(name, namespace, status_obj, status, reason=None, backend=None, endpoint=None, broker_name=None):

--- a/hybridcloud/handlers/queue.py
+++ b/hybridcloud/handlers/queue.py
@@ -5,84 +5,99 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import patch_namespaced_custom_object_status, create_or_update_secret, get_secret, delete_secret
 from ..util import k8s
 from ..util.constants import BACKOFF
+from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
 from .helpers import wait_for_amqp_broker
 
+_HANDLER_NAME = "queue"
+initialize_prometheus_metrics(_HANDLER_NAME)
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
     def queue_resume(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-        queue_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
+        _ACTION_NAME = ACTIONS.RESUME
+        PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
+
+        with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+            queue_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
 
 
 @kopf.on.create(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
 @kopf.on.update(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
 def queue_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-    if ignore_control_label_change(diff):
-        logger.debug("Only control labels removed. Nothing to do.")
-        return
+    _ACTION_NAME = ACTIONS.CREATE_OR_UPDATE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action="create_or_update").inc()
 
-    # Wait for broker
-    broker_namespace = spec["brokerRef"].get("namespace", namespace)
-    backend, backend_name, broker_name, allowed_k8s_namespaces = wait_for_amqp_broker(logger, broker_namespace, spec["brokerRef"]["name"], retry)
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if ignore_control_label_change(diff):
+            logger.debug("Only control labels removed. Nothing to do.")
+            return
 
-    # Check for cross-namespace
-    if broker_namespace != namespace:
-        if not config_get("cross_namespace.allow_produce", default=False):
-            _status(name, namespace, status, "failed", f"AMQPBroker and AMQPQueue in different k8s namespaces is not allowed")
-            raise kopf.PermanentError("AMQPBroker and AMQPQueue in different k8s namespaces is not allowed")
-        if not namespace in allowed_k8s_namespaces:
-            _status(name, namespace, status, "failed", f"Your k8s namespace is not allowed to use the referenced AMQPBroker")
-            raise kopf.PermanentError(f"Your k8s namespace is not allowed to use the referenced AMQPBroker")  
+        # Wait for broker
+        broker_namespace = spec["brokerRef"].get("namespace", namespace)
+        backend, backend_name, broker_name, allowed_k8s_namespaces = wait_for_amqp_broker(logger, broker_namespace, spec["brokerRef"]["name"], retry)
 
-    # Validate spec
-    valid, reason = backend.queue_spec_valid(namespace, name, spec, broker_name)
-    if not valid:
-        _status(name, namespace, status, "failed", f"Validation failed: {reason}")
-        raise kopf.PermanentError("Spec is invalid, check status for details")
+        # Check for cross-namespace
+        if broker_namespace != namespace:
+            if not config_get("cross_namespace.allow_produce", default=False):
+                _status(name, namespace, status, "failed", f"AMQPBroker and AMQPQueue in different k8s namespaces is not allowed")
+                raise kopf.PermanentError("AMQPBroker and AMQPQueue in different k8s namespaces is not allowed")
+            if not namespace in allowed_k8s_namespaces:
+                _status(name, namespace, status, "failed", f"Your k8s namespace is not allowed to use the referenced AMQPBroker")
+                raise kopf.PermanentError(f"Your k8s namespace is not allowed to use the referenced AMQPBroker")  
 
-    _status(name, namespace, status, "working", backend=backend_name, broker_name=broker_name)
+        # Validate spec
+        valid, reason = backend.queue_spec_valid(namespace, name, spec, broker_name)
+        if not valid:
+            _status(name, namespace, status, "failed", f"Validation failed: {reason}")
+            raise kopf.PermanentError("Spec is invalid, check status for details")
 
-    # Create queue
-    queue_name = backend.create_or_update_queue(namespace, name, spec, broker_name)
+        _status(name, namespace, status, "working", backend=backend_name, broker_name=broker_name)
 
-    credentials_secret = get_secret(namespace, spec["credentialsSecret"])
-    reset_credentials = False
+        # Create queue
+        queue_name = backend.create_or_update_queue(namespace, name, spec, broker_name)
 
-    def action_reset_credentials():
-        nonlocal credentials_secret
-        nonlocal reset_credentials
-        credentials_secret = None
-        reset_credentials = True
-        return "Credentials reset"
-    process_action_label(labels, {
-        "reset-credentials": action_reset_credentials,
-    }, body, k8s.AMQPQueue)
+        credentials_secret = get_secret(namespace, spec["credentialsSecret"])
+        reset_credentials = False
 
-    # Generate credentials
-    if not credentials_secret:
-        credentials = backend.create_or_update_queue_credentials(queue_name, broker_name, reset_credentials)
-        create_or_update_secret(namespace, spec["credentialsSecret"], credentials)
+        def action_reset_credentials():
+            nonlocal credentials_secret
+            nonlocal reset_credentials
+            credentials_secret = None
+            reset_credentials = True
+            return "Credentials reset"
+        process_action_label(labels, {
+            "reset-credentials": action_reset_credentials,
+        }, body, k8s.AMQPQueue)
 
-    # mark success
-    _status(name, namespace, status, "finished", "Queue created", backend=backend_name, broker_name=broker_name, queue_name=queue_name)
+        # Generate credentials
+        if not credentials_secret:
+            credentials = backend.create_or_update_queue_credentials(queue_name, broker_name, reset_credentials)
+            create_or_update_secret(namespace, spec["credentialsSecret"], credentials)
+
+        # mark success
+        _status(name, namespace, status, "finished", "Queue created", backend=backend_name, broker_name=broker_name, queue_name=queue_name)
 
 
 @kopf.on.delete(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
 def queue_delete(spec, status, name, namespace, logger, **kwargs):
-    if status and "backend" in status:
-        backend_name = status["backend"]
-    else:
-        backend_name = config_get("backend", fail_if_missing=True)
-    backend = amqp_backend(backend_name, logger)
-    if not status or not "broker_name" in status:
-        logger.warn("Could not delete queue as no broker information was stored in status")
-        return
-    broker_name = status["broker_name"]
+    _ACTION_NAME = ACTIONS.DELETE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
 
-    delete_secret(namespace, spec["credentialsSecret"])
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if status and "backend" in status:
+            backend_name = status["backend"]
+        else:
+            backend_name = config_get("backend", fail_if_missing=True)
+        backend = amqp_backend(backend_name, logger)
+        if not status or not "broker_name" in status:
+            logger.warn("Could not delete queue as no broker information was stored in status")
+            return
+        broker_name = status["broker_name"]
 
-    if backend.queue_exists(namespace, name, broker_name):
-        backend.delete_queue(namespace, name, broker_name)
+        delete_secret(namespace, spec["credentialsSecret"])
+
+        if backend.queue_exists(namespace, name, broker_name):
+            backend.delete_queue(namespace, name, broker_name)
 
 
 def _status(name, namespace, status_obj, status, reason=None, backend=None, broker_name=None, queue_name=None):

--- a/hybridcloud/handlers/queue.py
+++ b/hybridcloud/handlers/queue.py
@@ -5,11 +5,31 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import patch_namespaced_custom_object_status, create_or_update_secret, get_secret, delete_secret
 from ..util import k8s
 from ..util.constants import BACKOFF
-from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
 from .helpers import wait_for_amqp_broker
 
+from ..util.metrics import (
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, 
+    PROMETHEUS_HANDLER_EXCEPTION_COUNTER, 
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE,
+    ACTIONS,
+    extract_count_from_kopf_index, 
+    initialize_prometheus_handler_metrics, 
+    initialize_prometheus_resource_gauge
+)
+
 _HANDLER_NAME = "queue"
-initialize_prometheus_metrics(_HANDLER_NAME)
+_RESOURCE_TYPE = "AMQPQueue"
+initialize_prometheus_handler_metrics(_HANDLER_NAME)
+initialize_prometheus_resource_gauge(_RESOURCE_TYPE)
+
+
+@kopf.on.create(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
+@kopf.on.update(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
+@kopf.on.delete(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)
+def set_resource_count_metric(resource_index: kopf.Index, **_):
+    count = extract_count_from_kopf_index(resource_index, _RESOURCE_TYPE)
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE.labels(type=_RESOURCE_TYPE).set(count)
+
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPQueue.kopf_on(), backoff=BACKOFF)

--- a/hybridcloud/handlers/queue_consumer.py
+++ b/hybridcloud/handlers/queue_consumer.py
@@ -5,10 +5,29 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import get_namespaced_custom_object, patch_namespaced_custom_object_status, create_or_update_secret, get_secret, delete_secret
 from ..util import k8s
 from ..util.constants import BACKOFF
-from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
+from ..util.metrics import (
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, 
+    PROMETHEUS_HANDLER_EXCEPTION_COUNTER, 
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE,
+    ACTIONS,
+    extract_count_from_kopf_index, 
+    initialize_prometheus_handler_metrics, 
+    initialize_prometheus_resource_gauge
+)
 
 _HANDLER_NAME = "queue_consumer"
-initialize_prometheus_metrics(_HANDLER_NAME)
+_RESOURCE_TYPE = "AMQPQueueConsumer"
+initialize_prometheus_handler_metrics(_HANDLER_NAME)
+initialize_prometheus_resource_gauge(_RESOURCE_TYPE)
+
+
+@kopf.on.create(*k8s.AMQPQueueConsumer.kopf_on(), backoff=BACKOFF)
+@kopf.on.update(*k8s.AMQPQueueConsumer.kopf_on(), backoff=BACKOFF)
+@kopf.on.delete(*k8s.AMQPQueueConsumer.kopf_on(), backoff=BACKOFF)
+def set_resource_count_metric(resource_index: kopf.Index, **_):
+    count = extract_count_from_kopf_index(resource_index, _RESOURCE_TYPE)
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE.labels(type=_RESOURCE_TYPE).set(count)
+
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPQueueConsumer.kopf_on(), backoff=BACKOFF)

--- a/hybridcloud/handlers/topic.py
+++ b/hybridcloud/handlers/topic.py
@@ -5,84 +5,100 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import patch_namespaced_custom_object_status, create_or_update_secret, get_secret, delete_secret
 from ..util import k8s
 from ..util.constants import BACKOFF
+from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
 from .helpers import wait_for_amqp_broker
+
+_HANDLER_NAME = "topic"
+initialize_prometheus_metrics(_HANDLER_NAME)
 
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPTopic.kopf_on(), backoff=BACKOFF)
     def topic_resume(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-        topic_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
+        _ACTION_NAME = ACTIONS
+        PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
+
+        with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+            topic_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
 
 
 @kopf.on.create(*k8s.AMQPTopic.kopf_on(), backoff=BACKOFF)
 @kopf.on.update(*k8s.AMQPTopic.kopf_on(), backoff=BACKOFF)
 def topic_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-    if ignore_control_label_change(diff):
-        logger.debug("Only control labels removed. Nothing to do.")
-        return
+    _ACTION_NAME = ACTIONS.CREATE_OR_UPDATE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
 
-    # Wait for broker
-    broker_namespace = spec["brokerRef"].get("namespace", namespace)
-    backend, backend_name, broker_name, allowed_k8s_namespaces = wait_for_amqp_broker(logger, broker_namespace, spec["brokerRef"]["name"], retry)
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if ignore_control_label_change(diff):
+            logger.debug("Only control labels removed. Nothing to do.")
+            return
 
-    # Check for cross-namespace
-    if broker_namespace != namespace:
-        if not config_get("cross_namespace.allow_produce", default=False):
-            _status(name, namespace, status, "failed", f"AMQPBroker and AMQPTopic in different k8s namespaces is not allowed")
-            raise kopf.PermanentError("AMQPBroker and AMQPTopic in different k8s namespaces is not allowed")
-        if not namespace in allowed_k8s_namespaces:
-            _status(name, namespace, status, "failed", f"Your k8s namespace is not allowed to use the referenced AMQPBroker")
-            raise kopf.PermanentError(f"Your k8s namespace is not allowed to use the referenced AMQPBroker")  
+        # Wait for broker
+        broker_namespace = spec["brokerRef"].get("namespace", namespace)
+        backend, backend_name, broker_name, allowed_k8s_namespaces = wait_for_amqp_broker(logger, broker_namespace, spec["brokerRef"]["name"], retry)
 
-    # Validate spec
-    valid, reason = backend.topic_spec_valid(namespace, name, spec, broker_name)
-    if not valid:
-        _status(name, namespace, status, "failed", f"Validation failed: {reason}")
-        raise kopf.PermanentError("Spec is invalid, check status for details")
+        # Check for cross-namespace
+        if broker_namespace != namespace:
+            if not config_get("cross_namespace.allow_produce", default=False):
+                _status(name, namespace, status, "failed", f"AMQPBroker and AMQPTopic in different k8s namespaces is not allowed")
+                raise kopf.PermanentError("AMQPBroker and AMQPTopic in different k8s namespaces is not allowed")
+            if not namespace in allowed_k8s_namespaces:
+                _status(name, namespace, status, "failed", f"Your k8s namespace is not allowed to use the referenced AMQPBroker")
+                raise kopf.PermanentError(f"Your k8s namespace is not allowed to use the referenced AMQPBroker")  
 
-    _status(name, namespace, status, "working", backend=backend_name, broker_name=broker_name)
+        # Validate spec
+        valid, reason = backend.topic_spec_valid(namespace, name, spec, broker_name)
+        if not valid:
+            _status(name, namespace, status, "failed", f"Validation failed: {reason}")
+            raise kopf.PermanentError("Spec is invalid, check status for details")
 
-    # Create topic
-    topic_name = backend.create_or_update_topic(namespace, name, spec, broker_name)
+        _status(name, namespace, status, "working", backend=backend_name, broker_name=broker_name)
 
-    credentials_secret = get_secret(namespace, spec["credentialsSecret"])
-    reset_credentials = False
+        # Create topic
+        topic_name = backend.create_or_update_topic(namespace, name, spec, broker_name)
 
-    def action_reset_credentials():
-        nonlocal credentials_secret
-        nonlocal reset_credentials
-        credentials_secret = None
-        reset_credentials = True
-        return "Credentials reset"
-    process_action_label(labels, {
-        "reset-credentials": action_reset_credentials,
-    }, body, k8s.AMQPTopic)
+        credentials_secret = get_secret(namespace, spec["credentialsSecret"])
+        reset_credentials = False
 
-    # Generate credentials
-    if not credentials_secret:
-        credentials = backend.create_or_update_topic_credentials(topic_name, broker_name, reset_credentials)
-        create_or_update_secret(namespace, spec["credentialsSecret"], credentials)
+        def action_reset_credentials():
+            nonlocal credentials_secret
+            nonlocal reset_credentials
+            credentials_secret = None
+            reset_credentials = True
+            return "Credentials reset"
+        process_action_label(labels, {
+            "reset-credentials": action_reset_credentials,
+        }, body, k8s.AMQPTopic)
 
-    # mark success
-    _status(name, namespace, status, "finished", "Topic created", backend=backend_name, broker_name=broker_name, topic_name=topic_name)
+        # Generate credentials
+        if not credentials_secret:
+            credentials = backend.create_or_update_topic_credentials(topic_name, broker_name, reset_credentials)
+            create_or_update_secret(namespace, spec["credentialsSecret"], credentials)
+
+        # mark success
+        _status(name, namespace, status, "finished", "Topic created", backend=backend_name, broker_name=broker_name, topic_name=topic_name)
 
 
 @kopf.on.delete(*k8s.AMQPTopic.kopf_on(), backoff=BACKOFF)
 def topic_delete(spec, status, name, namespace, logger, **kwargs):
-    if status and "backend" in status:
-        backend_name = status["backend"]
-    else:
-        backend_name = config_get("backend", fail_if_missing=True)
-    backend = amqp_backend(backend_name, logger)
-    if not status or not "broker_name" in status:
-        logger.warn("Could not delete topic as no broker information was stored in status")
-        return
-    broker_name = status["broker_name"]
+    _ACTION_NAME = ACTIONS.DELETE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
 
-    delete_secret(namespace, spec["credentialsSecret"])
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if status and "backend" in status:
+            backend_name = status["backend"]
+        else:
+            backend_name = config_get("backend", fail_if_missing=True)
+        backend = amqp_backend(backend_name, logger)
+        if not status or not "broker_name" in status:
+            logger.warn("Could not delete topic as no broker information was stored in status")
+            return
+        broker_name = status["broker_name"]
 
-    if backend.topic_exists(namespace, name, broker_name):
-        backend.delete_topic(namespace, name, broker_name)
+        delete_secret(namespace, spec["credentialsSecret"])
+
+        if backend.topic_exists(namespace, name, broker_name):
+            backend.delete_topic(namespace, name, broker_name)
 
 
 def _status(name, namespace, status_obj, status, reason=None, backend=None, broker_name=None, topic_name=None):

--- a/hybridcloud/handlers/topic_subscription.py
+++ b/hybridcloud/handlers/topic_subscription.py
@@ -5,10 +5,28 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import get_namespaced_custom_object, patch_namespaced_custom_object_status, create_or_update_secret, get_secret, delete_secret
 from ..util import k8s
 from ..util.constants import BACKOFF
-from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
+from ..util.metrics import (
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, 
+    PROMETHEUS_HANDLER_EXCEPTION_COUNTER, 
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE,
+    ACTIONS,
+    extract_count_from_kopf_index, 
+    initialize_prometheus_handler_metrics, 
+    initialize_prometheus_resource_gauge
+)
 
 _HANDLER_NAME = "topic_subscription"
-initialize_prometheus_metrics(_HANDLER_NAME)
+_RESOURCE_TYPE = "AMQPTopicSubscription"
+initialize_prometheus_handler_metrics(_HANDLER_NAME)
+initialize_prometheus_resource_gauge(_RESOURCE_TYPE)
+
+
+@kopf.on.create(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
+@kopf.on.update(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
+@kopf.on.delete(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
+def set_resource_count_metric(resource_index: kopf.Index, **_):
+    count = extract_count_from_kopf_index(resource_index, _RESOURCE_TYPE)
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE.labels(type=_RESOURCE_TYPE).set(count)
 
 
 if config_get("handler_on_resume", default=False):

--- a/hybridcloud/handlers/topic_subscription.py
+++ b/hybridcloud/handlers/topic_subscription.py
@@ -5,86 +5,102 @@ from hybridcloud_core.operator.reconcile_helpers import ignore_control_label_cha
 from hybridcloud_core.k8s.api import get_namespaced_custom_object, patch_namespaced_custom_object_status, create_or_update_secret, get_secret, delete_secret
 from ..util import k8s
 from ..util.constants import BACKOFF
+from ..util.metrics import PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER, PROMETHEUS_HANDLER_EXCEPTION_COUNTER, ACTIONS, initialize_prometheus_metrics
+
+_HANDLER_NAME = "topic_subscription"
+initialize_prometheus_metrics(_HANDLER_NAME)
 
 
 if config_get("handler_on_resume", default=False):
     @kopf.on.resume(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
     def topic_subscription_resume(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-        topic_subscription_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
+        _ACTION_NAME = ACTIONS.RESUME
+        PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
+        
+        with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+            topic_subscription_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs)
 
 
 @kopf.on.create(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
 @kopf.on.update(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
 def topic_subscription_manage(spec, meta, labels, name, namespace, body, status, retry, diff, logger, **kwargs):
-    if ignore_control_label_change(diff):
-        logger.debug("Only control labels removed. Nothing to do.")
-        return
+    _ACTION_NAME = ACTIONS.CREATE_OR_UPDATE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
 
-    # Wait for topic
-    topic_namespace = spec["topicRef"].get("namespace", namespace)
-    backend, backend_name, broker_name, topic_name, allowed_k8s_namespaces = _wait_for_topic(logger, topic_namespace, spec["topicRef"]["name"], retry)
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if ignore_control_label_change(diff):
+            logger.debug("Only control labels removed. Nothing to do.")
+            return
 
-    # Check for cross-namespace
-    if topic_namespace != namespace:
-        if not config_get("cross_namespace.allow_consume", default=False):
-            _status(name, namespace, status, "failed", "Topic and Subscription in different k8s namespaces is not allowed")
-            raise kopf.PermanentError("Topic and Subscription in different k8s namespaces is not allowed")
-        if not namespace in allowed_k8s_namespaces:
-            _status(name, namespace, status, "failed", "Your k8s namespace is not allowed to use the referenced AMQPTopic")
-            raise kopf.PermanentError(f"Your k8s namespace is not allowed to zse the referenced AMQPTopic")  
+        # Wait for topic
+        topic_namespace = spec["topicRef"].get("namespace", namespace)
+        backend, backend_name, broker_name, topic_name, allowed_k8s_namespaces = _wait_for_topic(logger, topic_namespace, spec["topicRef"]["name"], retry)
 
-    # Validate spec
-    valid, reason = backend.topic_subscription_spec_valid(namespace, name, spec)
-    if not valid:
-        _status(name, namespace, status, "failed", f"Validation failed: {reason}")
-        raise kopf.PermanentError("Spec is invalid, check status for details")
+        # Check for cross-namespace
+        if topic_namespace != namespace:
+            if not config_get("cross_namespace.allow_consume", default=False):
+                _status(name, namespace, status, "failed", "Topic and Subscription in different k8s namespaces is not allowed")
+                raise kopf.PermanentError("Topic and Subscription in different k8s namespaces is not allowed")
+            if not namespace in allowed_k8s_namespaces:
+                _status(name, namespace, status, "failed", "Your k8s namespace is not allowed to use the referenced AMQPTopic")
+                raise kopf.PermanentError(f"Your k8s namespace is not allowed to zse the referenced AMQPTopic")  
 
-    _status(name, namespace, status, "working", backend=backend_name, topic_name=topic_name, broker_name=broker_name)
+        # Validate spec
+        valid, reason = backend.topic_subscription_spec_valid(namespace, name, spec)
+        if not valid:
+            _status(name, namespace, status, "failed", f"Validation failed: {reason}")
+            raise kopf.PermanentError("Spec is invalid, check status for details")
 
-    # Create topic subscription
-    subscription_name = backend.create_or_update_topic_subscription(namespace, name, spec, topic_name, broker_name)
+        _status(name, namespace, status, "working", backend=backend_name, topic_name=topic_name, broker_name=broker_name)
 
-    credentials_secret = get_secret(namespace, spec["credentialsSecret"])
-    reset_credentials = False
+        # Create topic subscription
+        subscription_name = backend.create_or_update_topic_subscription(namespace, name, spec, topic_name, broker_name)
 
-    def action_reset_credentials():
-        nonlocal credentials_secret
-        nonlocal reset_credentials
-        credentials_secret = None
-        reset_credentials = True
-        return "Credentials reset"
-    process_action_label(labels, {
-        "reset-credentials": action_reset_credentials,
-    }, body, k8s.AMQPTopicSubscription)
+        credentials_secret = get_secret(namespace, spec["credentialsSecret"])
+        reset_credentials = False
 
-    # Generate credentials
-    if not credentials_secret:
-        credentials = backend.create_or_update_topic_subscription_credentials(subscription_name, topic_name, broker_name, reset_credentials)
-        create_or_update_secret(namespace, spec["credentialsSecret"], credentials)
+        def action_reset_credentials():
+            nonlocal credentials_secret
+            nonlocal reset_credentials
+            credentials_secret = None
+            reset_credentials = True
+            return "Credentials reset"
+        process_action_label(labels, {
+            "reset-credentials": action_reset_credentials,
+        }, body, k8s.AMQPTopicSubscription)
 
-    # mark success
-    _status(name, namespace, status, "finished", "TopicSubscription created", backend=backend_name, broker_name=broker_name, topic_name=topic_name, subscription_name=subscription_name)
+        # Generate credentials
+        if not credentials_secret:
+            credentials = backend.create_or_update_topic_subscription_credentials(subscription_name, topic_name, broker_name, reset_credentials)
+            create_or_update_secret(namespace, spec["credentialsSecret"], credentials)
+
+        # mark success
+        _status(name, namespace, status, "finished", "TopicSubscription created", backend=backend_name, broker_name=broker_name, topic_name=topic_name, subscription_name=subscription_name)
 
 
 @kopf.on.delete(*k8s.AMQPTopicSubscription.kopf_on(), backoff=BACKOFF)
 def topic_subscription_delete(spec, status, name, namespace, logger, **kwargs):
-    if status and "backend" in status:
-        backend_name = status["backend"]
-    else:
-        backend_name = config_get("backend", fail_if_missing=True)
-    backend = amqp_backend(backend_name, logger)
-    if not status or not "broker_name" in status or not "topic_name" in status or not "subscription_name" in status:
-        logger.warn("Could not delete topic scubscription as no broker and topic information was stored in status")
-        return
-    broker_name = status["broker_name"]
-    topic_name = status["topic_name"]
-    subscription_name = status["subscription_name"]
+    _ACTION_NAME = ACTIONS.DELETE
+    PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
 
-    delete_secret(namespace, spec["credentialsSecret"])
+    with (PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME)).count_exceptions():
+        if status and "backend" in status:
+            backend_name = status["backend"]
+        else:
+            backend_name = config_get("backend", fail_if_missing=True)
+        backend = amqp_backend(backend_name, logger)
+        if not status or not "broker_name" in status or not "topic_name" in status or not "subscription_name" in status:
+            logger.warn("Could not delete topic scubscription as no broker and topic information was stored in status")
+            return
+        broker_name = status["broker_name"]
+        topic_name = status["topic_name"]
+        subscription_name = status["subscription_name"]
 
-    if backend.topic_subscription_exists(namespace, name, topic_name, broker_name):
-        backend.delete_topic_subscription(namespace, name, topic_name, broker_name)
-    backend.delete_topic_subscription_credentials(subscription_name, topic_name, broker_name)
+        delete_secret(namespace, spec["credentialsSecret"])
+
+        if backend.topic_subscription_exists(namespace, name, topic_name, broker_name):
+            backend.delete_topic_subscription(namespace, name, topic_name, broker_name)
+        backend.delete_topic_subscription_credentials(subscription_name, topic_name, broker_name)
 
 
 def _status(name, namespace, status_obj, status, reason=None, backend=None, broker_name=None, topic_name=None, subscription_name=None):

--- a/hybridcloud/operator.py
+++ b/hybridcloud/operator.py
@@ -2,9 +2,11 @@ import asyncio
 import logging
 import random
 import kopf
+import prometheus_client as prometheus
 # Import the handlers so kopf sees them
 from .handlers import broker, topic, topic_subscription, queue, queue_consumer
 
+prometheus.start_http_server(8081)
 
 logger = logging.getLogger('azure')
 logger.setLevel(logging.WARNING)

--- a/hybridcloud/util/metrics.py
+++ b/hybridcloud/util/metrics.py
@@ -1,5 +1,7 @@
 from typing import List
-from prometheus_client import Counter
+from prometheus_client import Counter, Gauge
+from . import k8s
+import kopf
 
 PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER = Counter(
     'handler_calls_total', 
@@ -13,6 +15,12 @@ PROMETHEUS_HANDLER_EXCEPTION_COUNTER = Counter(
     ["handler", "action"]
 )
 
+PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE = Gauge(
+    'resources_created_total', 
+    'Amount of resources created using the operator', 
+    ["type"]
+)
+
 class ACTIONS:
     RESUME = "resume"
     CREATE_OR_UPDATE = "create_or_update"
@@ -22,7 +30,30 @@ class ACTIONS:
         return [ACTIONS.RESUME, ACTIONS.CREATE_OR_UPDATE, ACTIONS.DELETE]
 
 
-def initialize_prometheus_metrics(handler_name: str, actions: List[str] = ACTIONS.list()) -> None:
+@kopf.index(*k8s.AMQPBroker.kopf_on())
+@kopf.index(*k8s.AMQPQueueConsumer.kopf_on())
+@kopf.index(*k8s.AMQPQueue.kopf_on())
+@kopf.index(*k8s.AMQPTopicSubscription.kopf_on())
+@kopf.index(*k8s.AMQPTopic.kopf_on())
+def resource_index(namespace, body, **_):
+    return { namespace: body.get("kind") }
+
+def initialize_prometheus_handler_metrics(handler_name: str, actions: List[str] = ACTIONS.list()) -> None:
     for action in actions:
         PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=handler_name, action=action)
         PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=handler_name, action=action)
+
+def initialize_prometheus_resource_gauge(type: str) -> None:
+    PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE.labels(type=type)
+
+def extract_count_from_kopf_index(index: kopf.Index, resource_type: str) -> int:
+    count = 0
+    resources = [] 
+    for value in index.values():
+        resources += value
+    
+    for resource in resources:
+        if resource == resource_type:
+            count += 1
+
+    return count

--- a/hybridcloud/util/metrics.py
+++ b/hybridcloud/util/metrics.py
@@ -1,0 +1,28 @@
+from typing import List
+from prometheus_client import Counter
+
+PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER = Counter(
+    'handler_calls_total', 
+    'Amount of times a handler has been called', 
+    ["handler", "action"]
+)
+
+PROMETHEUS_HANDLER_EXCEPTION_COUNTER = Counter(
+    'handler_exceptions_total', 
+    'Amount of exceptions thrown in kopf handlers', 
+    ["handler", "action"]
+)
+
+class ACTIONS:
+    RESUME = "resume"
+    CREATE_OR_UPDATE = "create_or_update"
+    DELETE = "delete"
+
+    def list():
+        return [ACTIONS.RESUME, ACTIONS.CREATE_OR_UPDATE, ACTIONS.DELETE]
+
+
+def initialize_prometheus_metrics(handler_name: str, actions: List[str] = ACTIONS.list()) -> None:
+    for action in actions:
+        PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=handler_name, action=action)
+        PROMETHEUS_HANDLER_EXCEPTION_COUNTER.labels(handler=handler_name, action=action)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ azure-identity==1.7.1
 azure-mgmt-resource==20.0.0
 azure-mgmt-servicebus==7.1.0
 requests==2.28.0
+prometheus-client==0.15.0
 git+https://github.com/MaibornWolff/hybrid-cloud-operator-library.git@c3de567


### PR DESCRIPTION
This PR introduces prometheus metrics to the operator. The supported metrics are the following prometheus metrics:

```python
PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER = Counter(
    'handler_calls_total', 
    'Amount of times a handler has been called', 
    ["handler", "action"]
)

PROMETHEUS_HANDLER_EXCEPTION_COUNTER = Counter(
    'handler_exceptions_total', 
    'Amount of exceptions thrown in kopf handlers', 
    ["handler", "action"]
)

PROMETHEUS_RESOURCES_CREATED_TOTAL_GAUGE = Gauge(
    'resources_created_total', 
    'Amount of resources created using the operator', 
    ["type"]
)
```

While handler calls and exceptions are maintained manually using calls like
```python
PROMETHEUS_HANDLER_CALLS_TOTAL_COUNTER.labels(handler=_HANDLER_NAME, action=_ACTION_NAME).inc()
```
the created resources are monitored using Kopfs [In Memory Index feature](https://kopf.readthedocs.io/en/stable/indexing/). This enables us to monitor resources of any kind without having to query the Kube API on a regular basis. 

Note: right now, it seems like the in-memory indices are only populated when a new resource is applied , but not when the operator starts up. This is unexpected behavior, since the docs suggest otherwise [here](https://kopf.readthedocs.io/en/stable/indexing/#limitations). Feel free to contribute or comment if you know more about this.

The metrics that are scraped by prometheus look like this in practice:
<img width="719" alt="Bildschirmfoto 2022-12-28 um 11 39 54" src="https://user-images.githubusercontent.com/25712873/209842679-4543eb6f-85ff-4997-ad1c-84cf0091277c.png">

